### PR TITLE
When playing MIDI in IPython, by default, don't override BPM to 120 in midicube.

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -22,7 +22,7 @@ export class PlayInstance {
         this.playing = false;
         this.timeWarp = 1;
         this.startDelay = 0;
-        this.BPM = 120;
+        this.BPM = undefined;
 
         this.data = [];
         this.eventQueue = []; // hold events to be triggered


### PR DESCRIPTION
The override was originally introduced in commit e5c56761b7a3862bf761b5ce4f3be1ddcdef03d1. Leave it undefined is more appropriate, since:
* The default in the next layer (jasmid) is 120 anyway, and
* The override will prevent jasmid from using SET_TEMPO events in the midi file, that means in IPython the tempo never changes according to the MIDI tempo changes. See [1]

[1] https://github.com/mscuthbert/midicube/blob/a652051de318edd02cecd0ab78aae570216624d3/inc/jasmid/replayer.js#L95